### PR TITLE
BSP:IO_Config:Remove useless i2c config and add touch key IO into gpi…

### DIFF
--- a/IO_Configuration/config.txt
+++ b/IO_Configuration/config.txt
@@ -13,7 +13,7 @@ arm_boost=1
 # other dtoverlay= specification
 dtparam=audio=on
 dtparam=i2s=on
-dtparam=i2c_arm=on
+#dtparam=i2c_arm=on
 dtparam=spi=on
 
 # Comment out the following line if the edges of the desktop appear outside
@@ -43,12 +43,12 @@ dtoverlay=uart3
 
 
 [all]
-# Required for mini pupper
-dtparam=i2c1
-dtoverlay=i2c3,pins_4_5
-dtoverlay=i2c4,pins_6_7
+# Required for mini pupper v2
 dtoverlay=spi0-1cs
-dtoverlay=i2c-pwm-pca9685a
 dtoverlay=audremap,pins_12_13
 dtparam=pwr_led_trigger=none
 dtparam=pwr_led_activelow=off
+dtoverlay=gpio-key,gpio=2,label=rear,keycode=240
+dtoverlay=gpio-key,gpio=3,label=right,keycode=240
+dtoverlay=gpio-key,gpio=6,label=front,keycode=240
+dtoverlay=gpio-key,gpio=16,label=left,keycode=240

--- a/IO_Configuration/config.txt
+++ b/IO_Configuration/config.txt
@@ -26,7 +26,9 @@ disable_overscan=1
 #hdmi_drive=2
 
 # Enable the serial pins
-enable_uart=1
+force_eeprom_read=0
+disable_poe_fan=1
+dtoverlay=uart2
 
 # Autoload overlays for any recognized cameras or displays that are attached
 # to the CSI/DSI ports. Please note this is for libcamera support, *not* for

--- a/esp32_proxy/esp32-proxy.cpp
+++ b/esp32_proxy/esp32-proxy.cpp
@@ -20,7 +20,7 @@
 static bool const print_debug     {false};
 static bool const print_debug_max {false};
 
-static char const * filename {"/dev/ttyAMA1"};
+static char const * filename {"/dev/ttyAMA2"};
 
 static char const * version = PROJECT_VER;
 


### PR DESCRIPTION
…o-key driver

## Proposed change(s)

Describe the changes made in this PR.

### Useful links (GitHub issues, forum threads, etc.)

Provide any relevant links here.

### Types of change(s)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which refactor the code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update only
- [ ] Other (please describe)

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions and ROS packages as appropriate so we can reproduce the test environment.

1. 1st command
2. 2nd command
3. ...

## Test Configuration

__Mini Pupper Version__  
[e.g. Simulator, Mini Pupper, Mini Pupper 2, Mini Pupper 2 Pro]

__Raspberry Pi OS + ROS version__  
[e.g. Ubuntu 22.04, ROS 2 Humble]

__PC OS + ROS version__  
[e.g. Ubuntu 22.04, ROS 2 Humble]

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/mangdangroboticsclub/mini_pupper_2_bsp/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.


## Other comments

<!-- Please write here if you have any other comments. -->
<!-- Also, if you have screenshots or videos, please share them here. -->
