### PR TITLE
ESP32 Firmware : Swap servo ID using CLI

### DIFF
--- a/esp32/main/mini_pupper_cmd.cpp
+++ b/esp32/main/mini_pupper_cmd.cpp
@@ -485,14 +485,14 @@ static int mini_pupper_cmd_setID(int argc, char **argv)
         printf("Invalid servo ID\r\n");
         return 0;
     }
-    if( servo_id>12 ) {
+    if( servo_id>12 && servo_id !=99) {
         printf("Invalid servo ID\r\n");
         return 0;
     }
 
     /* Check servo_newid "--newid" option */
     int servo_newid = servo_newid_args.servo_newid->ival[0];
-    if(servo_newid<0 || servo_newid>12) {
+    if( (servo_newid<0 || servo_newid>12) && servo_newid!=99) {
         printf("Invalid new servo ID\r\n");
         return 0;
     }


### PR DESCRIPTION

## Proposed change(s)

Add ID=99 into the white list of servo ids for servo-setID command (CLI).

### Useful links (GitHub issues, forum threads, etc.)

Provide any relevant links here.

### Types of change(s)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which refactor the code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update only
- [ ] Other (please describe)

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions and ROS packages as appropriate so we can reproduce the test environment.

1. 1st command
2. 2nd command
3. ...

## Test Configuration

__Mini Pupper Version__  
[e.g. Simulator, Mini Pupper, Mini Pupper 2, Mini Pupper 2 Pro]

__Raspberry Pi OS + ROS version__  
[e.g. Ubuntu 22.04, ROS 2 Humble]

__PC OS + ROS version__  
[e.g. Ubuntu 22.04, ROS 2 Humble]

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/mangdangroboticsclub/mini_pupper_2_bsp/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.


## Other comments

<!-- Please write here if you have any other comments. -->
<!-- Also, if you have screenshots or videos, please share them here. -->
