### PR TITLE
added new calibration tool

### DIFF
--- a/Python_Module/MangDang/mini_pupper/ESP32Interface.py
+++ b/Python_Module/MangDang/mini_pupper/ESP32Interface.py
@@ -1,5 +1,6 @@
 import socket
 import errno
+import time
 from struct import pack, unpack
 
 
@@ -43,6 +44,16 @@ class ESP32Interface:
 
     def servos_set_position(self, positions):
         torque = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        self.servos_set_position_torque(positions, torque)
+
+    def save_calibration(self):
+        # We signal the request by setting torque to an invalid value
+        torque = [99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99, 99]
+        positions = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        self.servos_set_position_torque(positions, torque)
+        time.sleep(0.5) # allow time for ESP32 to receive instruction
+        torque = [1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1]
+        positions = [512, 512, 512, 512, 512, 512, 512, 512, 512, 512, 512, 512]
         self.servos_set_position_torque(positions, torque)
 
     def servos_get_position(self):

--- a/Python_Module/MangDang/mini_pupper/calibrate.py
+++ b/Python_Module/MangDang/mini_pupper/calibrate.py
@@ -1,0 +1,104 @@
+import curses
+from MangDang.mini_pupper.ESP32Interface import ESP32Interface
+
+
+def draw_menu(stdscr):
+    k = 0
+    leg = 0
+    motor = 0
+    tabs = 0
+    esp32 = ESP32Interface()
+    positions = [512, 512, 512, 512, 512, 512, 512, 512, 512, 512, 512, 512]
+
+    # Clear and refresh the screen for a blank canvas
+    stdscr.clear()
+    stdscr.refresh()
+
+    # Start colors in curses
+    curses.start_color()
+    curses.init_pair(1, curses.COLOR_CYAN, curses.COLOR_BLACK)
+    curses.init_pair(2, curses.COLOR_RED, curses.COLOR_BLACK)
+    curses.init_pair(3, curses.COLOR_BLACK, curses.COLOR_WHITE)
+
+    # Loop where k is the last character pressed
+    while (k != ord('q')):
+        # Initialization
+        stdscr.clear()
+        height, width = stdscr.getmaxyx()
+
+        if k == 9:
+            tabs += 1
+            tabs = tabs % 12
+            leg = tabs % 4
+            motor = 0
+            if tabs > 3:
+                motor = 1
+            if tabs > 7:
+                motor = 2
+        elif k == curses.KEY_RIGHT:
+            index = 3 * leg + motor
+            positions[index] += 1
+            if positions[index] > 1023:
+                positions[index] = 1023
+        elif k == curses.KEY_LEFT:
+            index = 3 * leg + motor
+            positions[index] -= 1
+            if positions[index] < 0:
+                positions[index] = 0
+        elif k == ord('s'):
+            positions = [512, 512, 512, 512, 512, 512, 512, 512, 512, 512, 512, 512]
+            esp32.save_calibration()
+
+        esp32.servos_set_position(positions)
+
+        # Declaration of strings
+        statusbar1str = "Press tab to select motor | Press 'q' to exit | Press 's' to save"
+        statusbar2str = "%s | Press left/right arrow key to adjust motor" % get_motor_name(motor, leg)
+
+        # Rendering table
+        stdscr.attron(curses.color_pair(2))
+        stdscr.attron(curses.A_BOLD)
+        stdscr.addstr(0, 0, "" " * 20 + Mini Pupper Calibration Tool")
+
+        # Turning off attributes for title
+        stdscr.attroff(curses.color_pair(2))
+        stdscr.attroff(curses.A_BOLD)
+
+        # Render status bar
+        stdscr.attron(curses.color_pair(3))
+        stdscr.addstr(height-2, 0, statusbar1str)
+        stdscr.addstr(height-2, len(statusbar1str), " " * (width - len(statusbar1str) - 1))
+        stdscr.addstr(height-1, 0, statusbar2str)
+        stdscr.addstr(height-1, len(statusbar2str), " " * (width - len(statusbar2str) - 1))
+        stdscr.attroff(curses.color_pair(3))
+
+        stdscr.addstr(1, 0, "            front-right   front-left    back-right    back-left")
+        stdscr.addstr(2, 0, "abduction")
+        stdscr.addstr(3, 0, "hip")
+        stdscr.addstr(4, 0, "knee")
+
+        # Render selection
+        stdscr.attron(curses.color_pair(3))
+        stdscr.addstr(2 + motor, 12 + leg * 14, " " * 12)
+        stdscr.attroff(curses.color_pair(3))
+
+        # Refresh the screen
+        stdscr.refresh()
+
+        # Wait for next input
+        k = stdscr.getch()
+
+
+def get_motor_name(i, j):
+    motor_type = {0: "abduction", 1: "hip", 2: "knee"}  # Top  # Bottom
+    leg_pos = {0: "front-right", 1: "front-left", 2: "back-right", 3: "back-left"}
+    final_name = motor_type[i] + " " + leg_pos[j]
+    return final_name
+
+
+def main():
+    curses.wrapper(draw_menu)
+
+
+if __name__ == "__main__":
+    main()

--- a/Python_Module/setup.cfg
+++ b/Python_Module/setup.cfg
@@ -19,6 +19,8 @@ include_package_data = True
 * = *.png
 
 [entry_points]
+console_scripts =
+    calibrate = MangDang.mini_pupper.calibrate:main
 
 [pbr]
 autodoc_tree_index_modules = True

--- a/esp32/main/mini_pupper_app.h
+++ b/esp32/main/mini_pupper_app.h
@@ -6,6 +6,14 @@
 #ifndef _mini_pupper_app_H
 #define _mini_pupper_app_H
 
+#include "mini_pupper_types.h"
+
+#define MOUNT_PATH "/data"
+#define HISTORY_PATH MOUNT_PATH "/history.txt"
+#define CALIBRATE_PATH MOUNT_PATH "/calib.txt"
+
+static u16 const REF_ZERO_POSITION {512}; // Hard-coded REF/ZERO position for calibration (0..1023). TODO : from Flash ?
+
 enum e_mini_pupper_state
 {
     STATE_IDLE,
@@ -33,21 +41,12 @@ enum e_mini_pupper_state
     // SERVO are powered ON.
     // HOST service is disabled (torque switch and goal position setpoint are ignored, SERVO feedback OK, IMU feedback ok, POWER feedback ok)
 
-    STATE_RESTING,
+    STATE_RESTING
     // Mini pupper responds to HOST and CLI. 
     // IMU is working. 
     // SERVO are powered OFF.
     // HOST service is disabled (torque switch and goal position setpoint are ignored, SERVO feedback nOK, IMU feedback ok, POWER feedback ok)
     // This is an end state
-
-    STATE_CALIBRATION_START,
-    STATE_CALIBRATION,
-    STATE_CALIBRATION_FINISH
-    // Mini pupper is calibrating.
-    // IMU is working. 
-    // SERVO are powered ON.
-    // HOST service is disabled (torque switch and goal position setpoint are ignored, SERVO feedback OK, IMU feedback ok, POWER feedback ok)
-    // SERVO can be moved to ZERO/REF position by hand
 };
 
 extern e_mini_pupper_state state; 

--- a/esp32/main/mini_pupper_cmd.cpp
+++ b/esp32/main/mini_pupper_cmd.cpp
@@ -90,10 +90,10 @@ static void register_mini_pupper_cmd_enable(void)
 static int mini_pupper_cmd_isEnabled(int argc, char **argv)
 {
     if(servo.is_power_enabled()) {
-        printf("servos are enabled\r\n");
+        ESP_LOGI(TAG,"servos are enabled");
     }
     else{
-        printf("servos are not enabled\r\n");
+        ESP_LOGI(TAG,"servos are not enabled");
     }
     return 0;
 }
@@ -125,15 +125,15 @@ static int mini_pupper_cmd_disableTorque(int argc, char **argv)
 
     int servo_id = servo_id_args.servo_id->ival[0];
     if(servo_id<0) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     if( servo_id>12 && servo_id != 254 ) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     if( servo_id == 254) {
-        printf("Warning: your servo ID is the broadcast ID\r\n");
+        ESP_LOGI(TAG, "Warning: your servo ID is the broadcast ID");
     }
     servo.disable_torque((u8)servo_id);
     return 0;
@@ -164,15 +164,15 @@ static int mini_pupper_cmd_enableTorque(int argc, char **argv)
 
     int servo_id = servo_id_args.servo_id->ival[0];
     if(servo_id<0) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     if( servo_id>12 && servo_id != 254 ) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     if( servo_id == 254) {
-        printf("Warning: your servo ID is the broadcast ID\r\n");
+        ESP_LOGI(TAG, "Warning: your servo ID is the broadcast ID");
     }
     servo.enable_torque((u8)servo_id);
     return 0;
@@ -203,20 +203,20 @@ static int mini_pupper_cmd_isTorqueEnabled(int argc, char **argv)
 
     int servo_id = servo_id_args.servo_id->ival[0];
     if(servo_id<0) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     if( servo_id>12) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     u8 enable {0};
     servo.is_torque_enable((u8)servo_id,enable);
     if(enable) {
-        printf("servos torque is enabled\r\n");
+        ESP_LOGI(TAG, "servos torque is enabled");
     }
     else{
-        printf("servos torque is not enabled\r\n");
+        ESP_LOGI(TAG, "servos torque is not enabled");
     }
     return 0;
 }
@@ -242,15 +242,15 @@ static void register_mini_pupper_cmd_isTorqueEnabled(void)
 
 static int mini_pupper_cmd_scan(int argc, char **argv)
 {
-    printf("Servos on the bus:\r\n");
+    ESP_LOGI(TAG, "Servos on the bus:");
     for(u8 i = 1; i<13; i++)
     {
         if(servo.ping(i) == SERVO_STATUS_OK)
         {
-            printf("%d ", i);
+            ESP_LOGI(TAG, "%d ", i);
 	   }
     }
-    printf("\r\n");
+    ESP_LOGI(TAG, "");
     return 0;
 }
 
@@ -284,49 +284,13 @@ static void register_mini_pupper_cmd_extended_menu(void)
     ESP_ERROR_CHECK( esp_console_cmd_register(&cmd_extended_menu) );
 }
 
-static int mini_pupper_cmd_calibrate_begin(int argc, char **argv)
-{
-    state = STATE_CALIBRATION_START;
-    return 0;
-}
-
-static void register_mini_pupper_cmd_calibrate_begin(void)
-{
-    const esp_console_cmd_t cmd_calibrate = {
-        .command = "calibrate-begin",
-        .help = "begin mini pupper calibration",
-        .hint = NULL,
-        .func = &mini_pupper_cmd_calibrate_begin,
-           .argtable = NULL
-    };
-    ESP_ERROR_CHECK( esp_console_cmd_register(&cmd_calibrate) );
-}
-
-static int mini_pupper_cmd_calibrate_end(int argc, char **argv)
-{
-    state = STATE_CALIBRATION_FINISH;
-    return 0;
-}
-
-static void register_mini_pupper_cmd_calibrate_end(void)
-{
-    const esp_console_cmd_t cmd_calibrate = {
-        .command = "calibrate-end",
-        .help = "end mini pupper calibration",
-        .hint = NULL,
-        .func = &mini_pupper_cmd_calibrate_end,
-           .argtable = NULL
-    };
-    ESP_ERROR_CHECK( esp_console_cmd_register(&cmd_calibrate) );
-}
-
 static int mini_pupper_cmd_calibrate_clear(int argc, char **argv)
 {
   if (remove("/data//calib.txt") == 0) {
-      printf("The calibration file is deleted successfully.");
+      ESP_LOGI(TAG, "The calibration file is deleted successfully.");
       servo.resetCalibration();
   } else {
-      printf("The calibration file is not deleted.");
+      ESP_LOGI(TAG, "The calibration file is not deleted.");
   }
   return 0;
 }
@@ -396,21 +360,21 @@ static int mini_pupper_cmd_setPosition(int argc, char **argv)
     /* Check servoID "--id" option */
     int servo_id = servo_pos_args.servo_id->ival[0];
     if(servo_id<0) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     if( servo_id>12 && servo_id != 254 ) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     if( servo_id == 254) {
-        printf("Warning: your servo ID is the broadcast ID\r\n");
+        ESP_LOGI(TAG, "Warning: your servo ID is the broadcast ID");
     }
 
     /* Check servo_pos "--pos" option */
     int servo_pos = servo_pos_args.servo_pos->ival[0];
     if(servo_pos<0 || servo_pos>1023) {
-        printf("Invalid servo position\r\n");
+        ESP_LOGI(TAG, "Invalid servo position");
         return 0;
     }
     servo.set_goal_position((u8)servo_id, (u16)servo_pos);
@@ -482,18 +446,18 @@ static int mini_pupper_cmd_setID(int argc, char **argv)
     /* Check servoID "--id" option */
     int servo_id = servo_newid_args.servo_id->ival[0];
     if(servo_id<0) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     if( servo_id>12 && servo_id !=99) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
 
     /* Check servo_newid "--newid" option */
     int servo_newid = servo_newid_args.servo_newid->ival[0];
     if( (servo_newid<0 || servo_newid>12) && servo_newid!=99) {
-        printf("Invalid new servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid new servo ID");
         return 0;
     }
     servo.setID((u8)servo_id, (u8)servo_newid);
@@ -527,17 +491,17 @@ static int mini_pupper_cmd_getPosition(int argc, char **argv)
     int servo_id = servo_id_loop_args.servo_id->ival[0];
     int loop = servo_id_loop_args.loop->ival[0];
     if(servo_id<0) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     if( servo_id>12 ) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     for(int i=0; i<loop; i++){
         u16 position {0};
         servo.get_position((u8)servo_id, position);
-        printf("Pos: %d\r\n", position);
+        ESP_LOGI(TAG, "Pos: %d", position);
         vTaskDelay(1000 / portTICK_PERIOD_MS);
     }
     return 0;
@@ -570,17 +534,17 @@ static int mini_pupper_cmd_getSpeed(int argc, char **argv)
     int servo_id = servo_id_loop_args.servo_id->ival[0];
     int loop = servo_id_loop_args.loop->ival[0];
     if(servo_id<0) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     if( servo_id>12 ) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     for(int i=0; i<loop; i++){
         s16 speed {0};
         servo.get_speed((u8)servo_id,speed);
-        printf("Speed: %d\r\n", speed);
+        ESP_LOGI(TAG, "Speed: %d", speed);
         vTaskDelay(1000 / portTICK_PERIOD_MS);
     }
     return 0;
@@ -613,17 +577,17 @@ static int mini_pupper_cmd_getLoad(int argc, char **argv)
     int servo_id = servo_id_loop_args.servo_id->ival[0];
     int loop = servo_id_loop_args.loop->ival[0];
     if(servo_id<0) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     if( servo_id>12 ) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     for(int i=0; i<loop; i++){
         s16 load {0};
         servo.get_load((u8)servo_id,load);
-        printf("Load: %d\r\n", load);
+        ESP_LOGI(TAG, "Load: %d", load);
         vTaskDelay(1000 / portTICK_PERIOD_MS);
     }
     return 0;
@@ -656,17 +620,17 @@ static int mini_pupper_cmd_getVoltage(int argc, char **argv)
     int servo_id = servo_id_loop_args.servo_id->ival[0];
     int loop = servo_id_loop_args.loop->ival[0];
     if(servo_id<0) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     if( servo_id>12 ) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     for(int i=0; i<loop; i++){
         u8 voltage {0};
         servo.get_voltage((u8)servo_id,voltage);
-        printf("Voltage: %d\r\n", voltage);
+        ESP_LOGI(TAG, "Voltage: %d", voltage);
         vTaskDelay(1000 / portTICK_PERIOD_MS);
     }
     return 0;
@@ -699,17 +663,17 @@ static int mini_pupper_cmd_getTemperature(int argc, char **argv)
     int servo_id = servo_id_loop_args.servo_id->ival[0];
     int loop = servo_id_loop_args.loop->ival[0];
     if(servo_id<0) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     if( servo_id>12 ) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     for(int i=0; i<loop; i++){
         u8 temperature {0};
         servo.get_temperature((u8)servo_id,temperature);
-        printf("Temp: %d\r\n", temperature);
+        ESP_LOGI(TAG, "Temp: %d", temperature);
         vTaskDelay(1000 / portTICK_PERIOD_MS);
     }
     return 0;
@@ -742,17 +706,17 @@ static int mini_pupper_cmd_getMove(int argc, char **argv)
     int servo_id = servo_id_loop_args.servo_id->ival[0];
     int loop = servo_id_loop_args.loop->ival[0];
     if(servo_id<0) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     if( servo_id>12 ) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     for(int i=0; i<loop; i++){
         u8 move {0};
         servo.get_move((u8)servo_id,move);
-        printf("Move: %d\r\n", move);
+        ESP_LOGI(TAG, "Move: %d", move);
         vTaskDelay(1000 / portTICK_PERIOD_MS);
     }
     return 0;
@@ -785,17 +749,17 @@ static int mini_pupper_cmd_getCurrent(int argc, char **argv)
     int servo_id = servo_id_loop_args.servo_id->ival[0];
     int loop = servo_id_loop_args.loop->ival[0];
     if(servo_id<0) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     if( servo_id>12 ) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     for(int i=0; i<loop; i++){
         s16 current {0};
         servo.get_current((u8)servo_id,current);
-        printf("Current: %d\r\n", current);
+        ESP_LOGI(TAG, "Current: %d", current);
         vTaskDelay(1000 / portTICK_PERIOD_MS);
     }
     return 0;
@@ -827,21 +791,21 @@ static int mini_pupper_cmd_setPositionAsync(int argc, char **argv)
     /* Check servoID "--id" option */
     int servo_id = servo_pos_args.servo_id->ival[0];
     if(servo_id<0) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     if( servo_id>12 && servo_id != 254 ) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     if( servo_id == 254) {
-        printf("Warning: your servo ID is the broadcast ID\r\n");
+        ESP_LOGI(TAG, "Warning: your servo ID is the broadcast ID");
     }
 
     /* Check servo_pos "--pos" option */
     int servo_pos = servo_pos_args.servo_pos->ival[0];
     if(servo_pos<0 || servo_pos>1023) {
-        printf("Invalid servo position\r\n");
+        ESP_LOGI(TAG, "Invalid servo position");
         return 0;
     }
     servo.setPositionAsync((u8)servo_id, (u16)servo_pos);
@@ -908,14 +872,14 @@ static int mini_pupper_cmd_getPositionAsync(int argc, char **argv)
     /* Check servoID "--id" option */
     int servo_id = servo_id_args.servo_id->ival[0];
     if(servo_id<=0) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     if( servo_id>12 ) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
-    printf("Pos: %d\r\n", servo.getPositionAsync((u8)servo_id));
+    ESP_LOGI(TAG, "Pos: %d", servo.getPositionAsync((u8)servo_id));
     return 0;
 }
 
@@ -944,14 +908,14 @@ static int mini_pupper_cmd_getSpeedAsync(int argc, char **argv)
     /* Check servoID "--id" option */
     int servo_id = servo_id_args.servo_id->ival[0];
     if(servo_id<=0) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     if( servo_id>12 ) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
-    printf("ReadVel: %d\r\n", servo.getSpeedAsync((u8)servo_id));
+    ESP_LOGI(TAG, "ReadVel: %d", servo.getSpeedAsync((u8)servo_id));
     return 0;
 }
 
@@ -980,14 +944,14 @@ static int mini_pupper_cmd_getLoadAsync(int argc, char **argv)
     /* Check servoID "--id" option */
     int servo_id = servo_id_args.servo_id->ival[0];
     if(servo_id<=0) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
     if( servo_id>12 ) {
-        printf("Invalid servo ID\r\n");
+        ESP_LOGI(TAG, "Invalid servo ID");
         return 0;
     }
-    printf("Load: %d\r\n", servo.getLoadAsync((u8)servo_id));
+    ESP_LOGI(TAG, "Load: %d", servo.getLoadAsync((u8)servo_id));
     return 0;
 }
 
@@ -1071,8 +1035,6 @@ void register_mini_pupper_cmds(void)
 {
     register_mini_pupper_cmd_scan();
     register_mini_pupper_cmd_setID();
-    register_mini_pupper_cmd_calibrate_begin();
-    register_mini_pupper_cmd_calibrate_end();
     register_mini_pupper_cmd_calibrate_clear();
     register_mini_pupper_cmd_ota();
     // register_mini_pupper_cmd_extended_menu();

--- a/esp32/main/mini_pupper_host.h
+++ b/esp32/main/mini_pupper_host.h
@@ -37,6 +37,7 @@ private:
     bool _is_service_enabled {false};
     
     protocol_interpreter_handler _protocol_handler;
+    parameters_control_instruction_format prot_parameters;
 
     // background host serial bus service
     TaskHandle_t _task_handle {NULL};    

--- a/esp32/main/mini_pupper_host_base.h
+++ b/esp32/main/mini_pupper_host_base.h
@@ -55,6 +55,7 @@
 
 // host instruction code
 #define INST_CONTROL 0x01   // Host sends servo position setpoints, ESP32 replies with servo feedback, attitude, ....
+#define INST_SAVECALIBRATION 0x02   // Host requests to save calibration file
 
 // frame parameters format for control instruction
 struct parameters_control_instruction_format

--- a/esp32/main/mini_pupper_servos.cpp
+++ b/esp32/main/mini_pupper_servos.cpp
@@ -1114,6 +1114,11 @@ void SERVO::resetCalibration()
         state[index].calibration_offset = 0;
 }
 
+s16 SERVO::getCalibrationOffset(u8 const servoID)
+{
+    return state[servoID].calibration_offset;
+}
+
 u16 SERVO::raw_to_calibrated_position(u16 raw_position, s16 calibration_offset) const
 {
     s16 new_position {static_cast<s16>(raw_position)};

--- a/esp32/main/mini_pupper_servos.h
+++ b/esp32/main/mini_pupper_servos.h
@@ -218,6 +218,7 @@ struct SERVO
     int setID(u8 ID, u8 newID);
     void setCalibration(s16 const offset[]);
     void resetCalibration();
+    s16 getCalibrationOffset(u8 const servoID);
 
     /* ASYNC API 
      *
@@ -250,6 +251,10 @@ struct SERVO
     void getPosition12Async(u16 servoPositions[]);    
     void getSpeed12Async(s16 servoSpeeds[]);    
     void getLoad12Async(s16 servoLoads[]);    
+
+    // calibration helpers
+    u16 raw_to_calibrated_position(u16 raw_position, s16 calibration_offset) const;
+    u16 calibrated_to_raw_position(u16 calibrated_position, s16 calibration_offset) const;
 
     // public stats
     mini_pupper::periodic_process_monitor p_monitor;
@@ -297,10 +302,6 @@ protected:
     int check_reply_frame_no_parameter(u8 & ID);
 
     int uart_port_num {1};
-
-    // calibration helpers
-    u16 raw_to_calibrated_position(u16 raw_position, s16 calibration_offset) const;
-    u16 calibrated_to_raw_position(u16 calibrated_position, s16 calibration_offset) const;
 };
 
 extern SERVO servo;

--- a/esp32_proxy/esp32-proxy.cpp
+++ b/esp32_proxy/esp32-proxy.cpp
@@ -149,6 +149,12 @@ void esp32_protocol(setpoint_and_feedback_data * control_block)
         };
         memcpy(tx_buffer+5,&control_block->control,sizeof(parameters_control_instruction_format));
 
+	// If torque is set to 99 we want to save calibration
+        if(tx_buffer[5] == 99)
+	{
+	    tx_buffer[4] = INST_SAVECALIBRATION;
+	}
+
         // Checksum
         tx_buffer[tx_buffer_size-1] = compute_checksum(tx_buffer);
 

--- a/esp32_proxy/mini_pupper_host_base.h
+++ b/esp32_proxy/mini_pupper_host_base.h
@@ -10,6 +10,7 @@
 
 // host instruction code
 #define INST_CONTROL 0x01   // Host sends servo position setpoints, ESP32 replies with servo feedback, attitude, ....
+#define INST_SAVECALIBRATION 0x02   // Host requests to save calibration file
 
 // frame parameters format for control instruction
 struct parameters_control_instruction_format


### PR DESCRIPTION
## Proposed change(s)

This changes the way we do calibration. Calling "calibrate" on the RPi will open a TUI (terminal user interface) that makes any graphical or basic cli tool obsolete. You can now save the calibration from RPi and you can recalibrate any time. Calibration commands are removed from esp32-cli, just the option to remove the calibration file is left.

I mark it as a breaking change as you have to update ESP32 as well. Applications still *might* work even if esp32 is not updated but I have not tested this and I will not spend time time to it work when the real fix is to upgrade ESP32 code 

### Useful links (GitHub issues, forum threads, etc.)

Provide any relevant links here.

### Types of change(s)

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which refactor the code)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update only
- [ ] Other (please describe)

## Testing and Verification

Please describe the tests that you ran to verify your changes. Please also provide instructions and ROS packages as appropriate so we can reproduce the test environment.

1. 1st command
2. 2nd command
3. ...

## Test Configuration

__Mini Pupper Version__  
[e.g. Simulator, Mini Pupper, Mini Pupper 2, Mini Pupper 2 Pro]

__Raspberry Pi OS + ROS version__  
[e.g. Ubuntu 22.04, ROS 2 Humble]

__PC OS + ROS version__  
[e.g. Ubuntu 22.04, ROS 2 Humble]

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/mangdangroboticsclub/mini_pupper_2_bsp/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.


## Other comments

<!-- Please write here if you have any other comments. -->
<!-- Also, if you have screenshots or videos, please share them here. -->
