### PR TITLE
Fix Mic/Audio record volume is too small

### DIFF
--- a/demos/audio_test.py
+++ b/demos/audio_test.py
@@ -1,0 +1,52 @@
+#!/usr/bin/env python3
+#
+# Copyright 2023 MangDang
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# Author: Herman Ye @MangDang
+# Description: Mini Pupper audio record and playback script.
+#
+import sounddevice as sd
+import soundfile as sf
+import time
+import os
+
+# Audio record parameters
+fs = 48000  # 48KHz,Audio sampling rate
+duration = 5  # Recording duration in seconds
+
+# Set the default speaker volume to maximum
+# Headphone number is 0 without HDMI output
+# Headphone number is 1 when HDMI connect the display
+os.system("amixer -c 0 sset 'Headphone' 100%")
+
+print("Mini Pupper 2 audio record start...")
+record = sd.rec(int(duration * fs), samplerate=fs, channels=2)
+sd.wait()  # Wait for record to finish
+print("Mini Pupper 2 audio record end.")
+
+# Increase the volume [manually]
+record *= 100
+
+# Save the record
+sf.write('/tmp/mini-pupper-2-audio_test.wav', record, fs)
+
+# Wait for 1 second to playback
+time.sleep(1)
+
+# Play audio
+print("Mini Pupper 2 audio playback start...")
+sd.play(record, fs)
+sd.wait()  # Wait for playback to finish
+print("Mini Pupper 2 audio playback end.")

--- a/demos/audio_test.sh
+++ b/demos/audio_test.sh
@@ -1,6 +1,0 @@
-#!/bin/bash
-
-cardnums=$(arecord -l  | grep card | cut -d ' ' -f 2 | cut -d ':' -f 1)
-arecord -D plughw:$cardnums -d 5 -c2 -r 16000 -f S16_LE -t wav -V stereo -v /tmp/test-mic.wav 
-cardnums==$(aplay -l  | grep Headphones | cut -d ' ' -f 2 | cut -d ':' -f 1)
-aplay -D plughw:$cardnums /tmp/test-mic.wav

--- a/install.sh
+++ b/install.sh
@@ -50,7 +50,7 @@ echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selecti
 sudo sed -i "s/# deb-src/deb-src/g" /etc/apt/sources.list
 sudo apt update
 sudo apt -y upgrade
-sudo apt install -y i2c-tools dpkg-dev curl python-is-python3 mpg321 python3-tk openssh-server screen alsa-utils
+sudo apt install -y i2c-tools dpkg-dev curl python-is-python3 mpg321 python3-tk openssh-server screen alsa-utils libportaudio2
 sudo sed -i "s/pulse/alsa/" /etc/libao.conf
 if [ $(lsb_release -cs) == "jammy" ]; then
     sudo sed -i "s/cards.pcm.front/cards.pcm.default/" /usr/share/alsa/alsa.conf
@@ -78,6 +78,7 @@ cd /tmp
 wget --no-check-certificate https://bootstrap.pypa.io/get-pip.py
 sudo python get-pip.py
 sudo pip install setuptools==58.2.0 # temporary fix https://github.com/mangdangroboticsclub/mini_pupper_ros/pull/45#discussion_r1104759104
+sudo pip install sounddevice soundfile
 
 ### Install Python module
 sudo apt install -y python3-dev


### PR DESCRIPTION
## Proposed change(s)

Fix the audio record volume is too small

### Useful links (GitHub issues, forum threads, etc.)

https://github.com/mangdangroboticsclub/mini_pupper_2_issues/issues/9

### Types of change(s)

<!-- Select one or more -->

- [ *] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which refactor the code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update only
- [ ] Other (please describe)

## Testing and Verification

<!-- Please describe the tests that you ran to verify your changes. Please also provide instructions as appropriate so we can reproduce the test environment. -->

1. install the modules
2. python ~/mini_pupper_bsp/demos/audio_test.py

## Test Configuration

Mini Pupper 2

__Raspberry Pi OS version__  
Ubuntu 22.04 + mini_pupper_2_bsp repo

## Checklist

- [* ] I have read the [CONTRIBUTING](https://github.com/mangdangroboticsclub/mini_pupper_2_bsp/blob/main/CONTRIBUTING.md) guidelines.
- [* ] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.


## Other comments

<!-- Please write here if you have any other comments. -->
<!-- Also, if you have screenshots or videos, please share them here. -->
