### PR TITLE
Remove useless i2c config, update the config, add a missing dependency library for audio

### DIFF
--- a/IO_Configuration/config.txt
+++ b/IO_Configuration/config.txt
@@ -13,7 +13,7 @@ arm_boost=1
 # other dtoverlay= specification
 dtparam=audio=on
 dtparam=i2s=on
-dtparam=i2c_arm=on
+#dtparam=i2c_arm=on
 dtparam=spi=on
 
 # Comment out the following line if the edges of the desktop appear outside
@@ -43,12 +43,12 @@ dtoverlay=uart3
 
 
 [all]
-# Required for mini pupper
-dtparam=i2c1
-dtoverlay=i2c3,pins_4_5
-dtoverlay=i2c4,pins_6_7
+# Required for mini pupper v2
 dtoverlay=spi0-1cs
-dtoverlay=i2c-pwm-pca9685a
 dtoverlay=audremap,pins_12_13
 dtparam=pwr_led_trigger=none
 dtparam=pwr_led_activelow=off
+dtoverlay=gpio-key,gpio=2,label=rear,keycode=240
+dtoverlay=gpio-key,gpio=3,label=right,keycode=240
+dtoverlay=gpio-key,gpio=6,label=front,keycode=240
+dtoverlay=gpio-key,gpio=16,label=left,keycode=240

--- a/IO_Configuration/config.txt
+++ b/IO_Configuration/config.txt
@@ -26,7 +26,9 @@ disable_overscan=1
 #hdmi_drive=2
 
 # Enable the serial pins
-enable_uart=1
+force_eeprom_read=0
+disable_poe_fan=1
+dtoverlay=uart2
 
 # Autoload overlays for any recognized cameras or displays that are attached
 # to the CSI/DSI ports. Please note this is for libcamera support, *not* for

--- a/esp32_proxy/esp32-proxy.cpp
+++ b/esp32_proxy/esp32-proxy.cpp
@@ -20,7 +20,7 @@
 static bool const print_debug     {false};
 static bool const print_debug_max {false};
 
-static char const * filename {"/dev/ttyAMA1"};
+static char const * filename {"/dev/ttyAMA2"};
 
 static char const * version = PROJECT_VER;
 

--- a/install.sh
+++ b/install.sh
@@ -50,7 +50,7 @@ echo 'debconf debconf/frontend select Noninteractive' | sudo debconf-set-selecti
 sudo sed -i "s/# deb-src/deb-src/g" /etc/apt/sources.list
 sudo apt update
 sudo apt -y upgrade
-sudo apt install -y i2c-tools dpkg-dev curl python-is-python3 mpg321 python3-tk openssh-server screen alsa-utils libportaudio2
+sudo apt install -y i2c-tools dpkg-dev curl python-is-python3 mpg321 python3-tk openssh-server screen alsa-utils libportaudio2 libsndfile1
 sudo sed -i "s/pulse/alsa/" /etc/libao.conf
 if [ $(lsb_release -cs) == "jammy" ]; then
     sudo sed -i "s/cards.pcm.front/cards.pcm.default/" /usr/share/alsa/alsa.conf


### PR DESCRIPTION
## Proposed change(s)

Remove useless i2c config, update the config
add a missing dependency library for audio

### Useful links (GitHub issues, forum threads, etc.)

N/A

### Types of change(s)

<!-- Select one or more -->

- [ *] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ *] Code refactor (non-breaking change which refactor the code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update only
- [ ] Other (please describe)

## Testing and Verification

1. cd ~/mini_pupper_bsp/demos/
2. try all the demos

## Test Configuration
Mini Pupper 2

__Raspberry Pi OS version__  
Ubuntu 22.04

## Checklist

- [ *] I have read the [CONTRIBUTING](https://github.com/mangdangroboticsclub/mini_pupper_2_bsp/blob/main/CONTRIBUTING.md) guidelines.
- [ *] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.


## Other comments

<!-- Please write here if you have any other comments. -->
<!-- Also, if you have screenshots or videos, please share them here. -->
