### PR TITLE
fixed error when injecting build date ino mini-pupper-release

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -7,7 +7,7 @@ BASEDIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
 
 ### Write release file
 echo BUILD_DATE=\"$(date)\" > ~/mini-pupper-release
-echo HARDWARE=\"$(python3 $BASEDIR/Python_Module/MangDang/mini_pupper/capabilities.py)\" > ~/mini-pupper-release
+echo HARDWARE=\"$(python3 $BASEDIR/Python_Module/MangDang/mini_pupper/capabilities.py)\" >> ~/mini-pupper-release
 echo MACHINE=\"$(uname -m)\" >> ~/mini-pupper-release
 if [ -f /boot/firmware/user-data ]
 then


### PR DESCRIPTION
## Proposed change(s)

<!-- Describe the changes made in this PR. -->

### Useful links (GitHub issues, forum threads, etc.)

<!-- Provide any relevant links here. -->

### Types of change(s)

<!-- Select one or more -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which refactor the code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update only
- [ ] Other (please describe)

## Testing and Verification

<!-- Please describe the tests that you ran to verify your changes. Please also provide instructions as appropriate so we can reproduce the test environment. -->

1. 1st command
2. 2nd command
3. ...

## Test Configuration

__Mini Pupper Version__  
<!-- [e.g. Mini Pupper, Mini Pupper 2, Mini Pupper 2 Pro] -->

__Raspberry Pi OS version__  
<!-- [e.g. Ubuntu 22.04] -->

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/mangdangroboticsclub/mini_pupper_2_bsp/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.


## Other comments

<!-- Please write here if you have any other comments. -->
<!-- Also, if you have screenshots or videos, please share them here. -->
