### PR TITLE
Feature/add default torque

### DIFF
--- a/Python_Module/MangDang/mini_pupper/HardwareInterface.py
+++ b/Python_Module/MangDang/mini_pupper/HardwareInterface.py
@@ -1,13 +1,14 @@
 from MangDang.mini_pupper.Config import ServoParams, PWMParams
 import numpy as np
 
+DEFAULT_TORQUE = [500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500, 500]
 
 class HardwareInterface:
     def __init__(self):
         self.pwm_params = PWMParams()
         self.servo_params = ServoParams()
 
-    def set_actuator_postions(self, joint_angles, torque):
+    def set_actuator_postions(self, joint_angles, torque=DEFAULT_TORQUE):
         send_servo_commands(self.pwm_params, self.servo_params, joint_angles, torque)
 
     def set_actuator_position(self, joint_angle, axis, leg):


### PR DESCRIPTION
## Proposed change(s)

At this stage, upper layer ROS2 packages still calls this interface without torque parameter. Add default value for torque for better compatibility. 

### Useful links (GitHub issues, forum threads, etc.)

<!-- Provide any relevant links here. -->

### Types of change(s)

<!-- Select one or more -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code refactor (non-breaking change which refactor the code)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update only
- [ ] Other (please describe)

## Testing and Verification

<!-- Please describe the tests that you ran to verify your changes. Please also provide instructions as appropriate so we can reproduce the test environment. -->

### Reproduce the issue
1. source ros2_ws/install/setup.bash
2. ros2 launch mini_pupper_bringup bringup.launch.py
### apply fix
1. sudo pip uninstall MangDang
2. git clone from https://github.com/CullenSUN/mini_pupper_2_bsp/tree/feature/add-default-torque
3. cd mini_pupper_bsp/Python_Module
4. sudo pip install .
5.  ros2 launch mini_pupper_bringup bringup.launch.py shall be ok now



## Test Configuration

__Mini Pupper Version__  
 Mini Pupper 2 Pro

__Raspberry Pi OS version__  
 Ubuntu 22.04

## before fix 
```
[servo_interface-6]     self.hardware_interface.set_actuator_postions(joint_angles)
[servo_interface-6] TypeError: HardwareInterface.set_actuator_postions() missing 1 required positional argument: 'torque'
[ERROR] [servo_interface-6]: process has died [pid 5311, exit code 1, cmd '/home/ubuntu/ros2_ws/install/mini_pupper_driver/lib/mini_pupper_driver/servo_interface --ros-args -r __node:=servo_interface'].
[ldlidar_stl_ros2_node-7] [ERROR] [1712586509.329575912] [LD06]: ldlidar communication is abnormal.
[ldlidar_stl_ros2_node-7] [LDS][INFO][1712586506.328470356][Actual BaudRate reported:230400]
[ERROR] [ldlidar_stl_ros2_node-7]: process has died [pid 5313, exit code 1, cmd '/home/ubuntu/ros2_ws/install/ldlidar_stl_ros2/lib/ldlidar_stl_ros2/ldlidar_stl_ros2_node --ros-args -r __node:=LD06 --params-file /tmp/launch_params_bjli_eql --params-file /tmp/launch_params_efgdpw7z --params-file /tmp/launch_params_ddmd2udj --params-file /tmp/launch_params_ll3lr2mp --params-file /tmp/launch_params_kc2a4wie --params-file /tmp/launch_params_kjd034zm --params-file /tmp/launch_params_ddszmggd --params-file /tmp/launch_params_hk5cp4rr --params-file /tmp/launch_params_682lmu4k'].

```

## After fix
the robot can be brought up without error.

## Checklist

- [x] I have read the [CONTRIBUTING](https://github.com/mangdangroboticsclub/mini_pupper_2_bsp/blob/main/CONTRIBUTING.md) guidelines.
- [x] I have checked to ensure there aren't other open [Pull Requests](../pulls) for the same change.


## Other comments

<!-- Please write here if you have any other comments. -->
<!-- Also, if you have screenshots or videos, please share them here. -->
